### PR TITLE
Implement matrix multiplication with pure Go

### DIFF
--- a/gogf127/gogf127.go
+++ b/gogf127/gogf127.go
@@ -160,23 +160,24 @@ func Add(a, b, c *GF127) {
 }
 
 // Mul sets c to a*b.
+// TODO make it work in-place without allocations
 // TODO optimization: no need to perform shift by i every time, cache results
 func Mul(a, b, c *GF127) {
-	c[0] = 0
-	c[1] = 0
+	r := new(GF127)
 	d := new(GF127)
 	for i := uint(0); i < 64; i++ {
 		if b[0]&(1<<i) != 0 {
 			shl(i, a, d)
-			Add(c, d, c)
+			Add(r, d, r)
 		}
 	}
 	for i := uint(0); i < 63; i++ {
 		if b[1]&(1<<i) != 0 {
 			shl(i+64, a, d)
-			Add(c, d, c)
+			Add(r, d, r)
 		}
 	}
+	*c = *r
 }
 
 // shl performs left shift by consecutive multiplications by 2.

--- a/tz/cpuid_x86.go
+++ b/tz/cpuid_x86.go
@@ -36,7 +36,7 @@ const (
 	bitAVX2    = 1 << 5
 )
 
-func init() {
+func setFeatures() {
 	maxID, _, _, _ := cpuid(0, 0)
 	if maxID < 1 {
 		return


### PR DESCRIPTION
Set suitable backend for GF127 arithmetic for Concat(), Sum() etc.

Fixes  #14.